### PR TITLE
New updates

### DIFF
--- a/zelnodeupdate.sh
+++ b/zelnodeupdate.sh
@@ -97,7 +97,7 @@ mkdir ~/zeltemp
 wget -c $WALLET_DOWNLOAD -O - | tar -xz -C ~/zeltemp
 #copy daemon files to bin directory and change perms to X
 sudo cp ~/zeltemp/zelcash* /usr/bin
-sudo chmod u+x /usr/bin/zelcash*
+sudo chmod 755 /usr/bin/zelcash*
 #remove temp files
 rm -rf $WALLET_TAR_FILE && rm -rf ~/zeltemp
 cd

--- a/zelnodeupdate.sh
+++ b/zelnodeupdate.sh
@@ -28,6 +28,7 @@ FETCHPARAMS='https://raw.githubusercontent.com/zelcash/zelcash/master/zcutil/fet
 #end of required details
 
 #Display script name and version
+clear
 echo -e '\033[1;33m==================================================================\033[0m'
 echo -e 'ZelNode Update, v1.0'
 echo -e '\033[1;33m==================================================================\033[0m'
@@ -61,11 +62,14 @@ echo "Installing package updates..."
 sudo apt-get update -y
 sudo apt-get upgrade -y
 echo -e "\033[1;32mLinux Packages Updates complete...\033[0m"
+sleep 2
 #Setup log rotation
 echo -e "\n\033[1;33mConfiguring log rotate function...\033[0m"
+sleep 1
 if [ -f /etc/logrotate.d/zeldebuglog ]; then
     echo -e "\033[1;36mExisting log rotate conf found, backing up to ~/zeldebuglogrotate.old ...\033[0m"
     sudo mv /etc/logrotate.d/zeldebuglog ~/zeldebuglogrotate.old;
+    sleep 2
 fi
 touch /home/$USERNAME/zeldebuglog
 cat <<EOM > /home/$USERNAME/zeldebuglog

--- a/zelnodeupdate.sh
+++ b/zelnodeupdate.sh
@@ -6,7 +6,7 @@
 
 #wallet information
 COIN_NAME='zelcash'
-WALLET_DOWNLOAD='https://github.com/zelcash/zelcash/releases/download/v3.0.0/ZelCash-Linux.tar.gz'
+WALLET_DOWNLOAD='https://github.com/zelcash/zelcash/releases/download/v3.1.0/ZelCash-Linux.tar.gz'
 WALLET_BOOTSTRAP='https://zelcore.io/zelcashbootstraptxindex.zip'
 BOOTSTRAP_ZIP_FILE='zelcashbootstraptxindex.zip'
 WALLET_TAR_FILE='ZelCash-Linux.tar.gz'


### PR DESCRIPTION
Updated ZelNode update script. This script will update the ZelNode daemon to 3.1.0 for users that used the main install script. We also added a OS update and logrotate conf to rotate the zelcashd devug.log files